### PR TITLE
chore(test): wallaby.js config

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "run-sequence": "1.2.1",
     "ts-loader": "0.8.2",
     "tslint": "3.10.2",
+    "wallaby-webpack": "0.0.22",
     "webpack": "1.13.1",
     "webpack-stream": "3.2.0",
     "xmldom": "0.1.22",

--- a/src/components/button/buttonDirective.ts
+++ b/src/components/button/buttonDirective.ts
@@ -1,8 +1,8 @@
 'use strict';
 
 import * as ng from 'angular';
-import {ButtonTypeEnum} from './buttonTypeEnum.ts';
-import {ButtonTemplateType} from './buttonTemplateType.ts';
+import {ButtonTypeEnum} from './buttonTypeEnum';
+import {ButtonTemplateType} from './buttonTemplateType';
 
 export interface IButtonScope extends ng.IScope {
   disabled: boolean;

--- a/src/components/dialog/dialogDirective.ts
+++ b/src/components/dialog/dialogDirective.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import * as ng from 'angular';
-import {DialogTypeEnum, DialogActionsPositionEnum} from './dialogEnums.ts';
+import {DialogTypeEnum, DialogActionsPositionEnum} from './dialogEnums';
 
 /**
  * @ngdoc interface

--- a/src/components/overlay/overlayDirective.ts
+++ b/src/components/overlay/overlayDirective.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import * as ng from 'angular';
-import {OverlayMode} from './overlayModeEnum.ts';
+import {OverlayMode} from './overlayModeEnum';
 
 /**
  * @ngdoc interface

--- a/wallaby.config.ts
+++ b/wallaby.config.ts
@@ -1,5 +1,5 @@
 import { IWallabyConfig, IWallabyEnvironment } from 'wallaby';
-import { BuildConfig } from './build';
+import { BuildConfig } from './build/config/build';
 
 class WallabyConfig implements IWallabyConfig {
 
@@ -8,27 +8,22 @@ class WallabyConfig implements IWallabyConfig {
    *                                copies to it's local cache.
    */
   public files: any = [
-    { instrument: false, pattern: BuildConfig.NODE_MODULES + '/phantomjs-polyfill/bind-polyfill.js'},
     { instrument: false, pattern: BuildConfig.NODE_MODULES + '/angular/angular.js'},
     { instrument: false, pattern: BuildConfig.NODE_MODULES + '/angular-mocks/angular-mocks.js'},
     { instrument: false, pattern: BuildConfig.NODE_MODULES + '/jquery/dist/jquery.min.js'},
-    // { instrument: false, pattern: BuildConfig.NODE_MODULES + '/pickadate/lib/picker.js'},
-    // { instrument: false, pattern: BuildConfig.NODE_MODULES + '/pickadate/lib/picker.date.js'},
+    { instrument: false, pattern: BuildConfig.NODE_MODULES + '/pickadate/lib/picker.js'},
+    { instrument: false, pattern: BuildConfig.NODE_MODULES + '/pickadate/lib/picker.date.js'},
     { instrument: false, pattern: BuildConfig.NODE_MODULES + '/jasmine-jquery/lib/jasmine-jquery.js'},
     { instrument: false, pattern: 'src/core/jquery.phantomjs.fix.js'},
-    'src/**/*.ts',
+    {pattern: 'src/**/*.ts', load: false},
     '!src/**/*.spec.ts'
   ];
 
   /**
    * @property  {string[]}  tests - Collection of files that include tests.
    */
-  public tests: string[] = [
-    //'src/**/*.spec.ts'
-    // 'src/components/*/!(*.spec|contextualMenu|navbarDirective).ts',
-    'src/components/navbar/navbarDirective.ts'
-    // 'src/components/contextualmenu/contextualMenu.ts',
-    // 'src/components/*/*.spec.ts'
+  public tests: any[] = [
+    {pattern: 'src/**/*.spec.ts', load: false}
   ];
 
   public env: IWallabyEnvironment = <IWallabyEnvironment>{
@@ -43,6 +38,26 @@ class WallabyConfig implements IWallabyConfig {
    */
   public compilers: any = {
     'src/**/*.ts': this.wallaby.compilers.typeScript()
+  };
+
+  public postprocessor: any = require('wallaby-webpack')({
+    entryPatterns: [
+      'src/core/components.js',
+      'src/core/core.js',
+      'src/**/*.spec.js'
+    ],
+    externals: {
+      'angular': 'angular'
+    },
+    resolve: {
+      extensions: ['', '.js', '.ts'],
+      root: './src'
+    }
+  });
+
+  public setup: any = function () {
+    // required to trigger test loading
+    window['__moduleBundler'].loadTests();
   };
 
   constructor(private wallaby: any) { }


### PR DESCRIPTION
Working wallaby.js config, changes overview:
- Wallaby config has to be on the same level (or above) of any paths it's referencing.
- Added `wallaby-webpack` dev dependency and configured wallaby for webpack as [described in the docs](https://wallabyjs.com/docs/integration/webpack.html). Specifically added webpack `postprocessor`, `setup` function, [used `entryPatterns`](https://wallabyjs.com/docs/integration/webpack.html#entry-patterns) for loading webpack-ed components, added `load: false` to files and tests that are supposed to be webpack-ed.
- Removed unnecessary and inconsistently used `.ts` extensions.

Closes https://github.com/wallabyjs/public/issues/708.
